### PR TITLE
Support linux user when calling with-show

### DIFF
--- a/src/gigasquid/numpy_plot.clj
+++ b/src/gigasquid/numpy_plot.clj
@@ -3,12 +3,10 @@
             [libpython-clj.python :as py :refer [py. py.. py.-]]
             [gigasquid.plot :as plot]))
 
-
 (require-python '[matplotlib.pyplot :as pyplot])
 (require-python '[numpy :as numpy])
 
 ;;;; you will need matplotlib, numpy, and pillow installed to run this in python3
-
 
 ;;; This uses a macro from printing in the plot namespace that uses the shell "open" command
 ;;; to show a saved image from pyplot. If you don't have a mac you will need to modify that
@@ -84,9 +82,7 @@
     (plot/with-show
       (let [[fig1 ax1] (pyplot/subplots)]
         (py. ax1 "pie" sizes :explode explode :labels labels :autopct "%1.1f%%"
-                             :shadow true :startangle 90)
+             :shadow true :startangle 90)
         (py. ax1 "axis" "equal")) ;equal aspec ration ensures that pie is drawn as circle
       ))
   )
-
-

--- a/src/gigasquid/opencv/core.clj
+++ b/src/gigasquid/opencv/core.clj
@@ -1,6 +1,7 @@
 (ns gigasquid.opencv.core
   (:require
    [clojure.string :as string]
+   [gigasquid.utils :refer [display-image]]
    [libpython-clj.require
     :refer [require-python]]
    [libpython-clj.python
@@ -118,27 +119,6 @@
   )
 
 ;; Re-usable function for exercising the above functions
-
-(def is-linux?
-  (= "linux"
-     (-> "os.name"
-         System/getProperty
-         string/lower-case)))
-
-(def is-mac?
-  (-> "os.name"
-      System/getProperty
-      string/lower-case
-      (string/starts-with? "mac")))
-
-(defn display-image
-  [image-file]
-  (cond
-    is-mac?
-    (sh/sh "open" image-file)
-
-    is-linux?
-    (sh/sh "display" image-file)))
 
 (defn process-image
   "Apply opencv function to a given image and optionally show it.

--- a/src/gigasquid/pygal/core.clj
+++ b/src/gigasquid/pygal/core.clj
@@ -8,9 +8,10 @@
                      py.-
                      att-type-map
                      ->python
-                     ->jvm
-                     ]]
+                     ->jvm]]
             [clojure.java.shell :as sh]
+            [gigasquid.utils :refer [create-tmp-file
+                                     display-image]]
             [clojure.pprint :refer [pprint]])
   (:import [java.io File]))
 
@@ -188,13 +189,13 @@
            \"Fibonacci\" [0 1 1 2 3 5 8 13 21 34 55]
            \"Padovan\" [1 1 1 2 2 3 4 5 7 9 12])"
   [graph & xs]
-  (let [tmp-file (File/createTempFile "tmp-output" ".svg")
+  (let [tmp-file (create-tmp-file "tmp-output" ".svg")
         output (.getAbsolutePath tmp-file)]
     (doseq [[x y]
             (partition 2 xs)]
       (py. graph add x y))
     (py. graph render_to_file output)
-    (sh/sh "open" output)
+    (display-image output)
     (.deleteOnExit tmp-file)))
 
 (comment
@@ -222,6 +223,7 @@
            "Narrow Bars" [[10 1 2]
                           [12 4 4.5]
                           [8 11 13]])
+
   )
 
 ;; XY - http://www.pygal.org/en/latest/documentation/types/xy.html
@@ -264,8 +266,8 @@
            )
 
   ;; Time
-
   (py/from-import datetime)
+
   ;; DateTime
   (pg-plot (pygal/DateTimeLine
             :title "DateTime Example"

--- a/src/gigasquid/utils.clj
+++ b/src/gigasquid/utils.clj
@@ -1,0 +1,36 @@
+(ns gigasquid.utils
+  (:require
+   [clojure.string :as string]
+   [clojure.java.shell :as sh]
+   [clojure.pprint :refer [pprint]])
+  (:import [java.io File]))
+
+(def is-linux?
+  (= "linux"
+     (-> "os.name"
+         System/getProperty
+         string/lower-case)))
+
+(def is-mac?
+  (-> "os.name"
+      System/getProperty
+      string/lower-case
+      (string/starts-with? "mac")))
+
+(defn display-image
+  "Display image on OSX or on Linux based system"
+  [image-file]
+  (cond
+    is-mac?
+    (sh/sh "open" image-file)
+
+    is-linux?
+    (sh/sh "display" image-file)))
+
+(defn create-tmp-file
+  "Return full path of temporary file.
+
+  Example:
+  (create-tmp-file \"tmp-image\" \".png\") "
+  [prefix ext]
+  (File/createTempFile prefix ext))


### PR DESCRIPTION
This PR include some improvement to the code `with-show`

- Add utils.clj that support display logic for OSX/Linux
- Create temp file and cleanup after ourself
- Refactoring pygal display to use shared logic in utils

I found that when trying the examples on my Ubuntu laptop, I could not plot the graph using
the current `with-show` thus, I already have the logic in `pygal` example that switch the logic
when calling `clojure.shell/sh` and it works well. So thus this make it more portable.
The code in OSX, should continue to work as before + the generated temp file will be removed after the with-show now. Thus making it more clean.

Let me know if you find any problem/issue.

Best,
Burin